### PR TITLE
configure: Bump required automake version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ dnl --program-transform-name options
 AC_ARG_PROGRAM
 
 dnl Fairly arbitrary, older versions might work too.
-AM_INIT_AUTOMAKE([1.11 foreign -Wno-portability])
+AM_INIT_AUTOMAKE([1.13 foreign -Wno-portability])
 AM_SILENT_RULES([yes])
 
 AM_EXTRA_RECURSIVE_TARGETS([help run todo fixme])


### PR DESCRIPTION
The AM_EXTRA_RECURSIVE_TARGETS macro used in configure.ac is a new
feature of automake < 1.13. This patch bumps the required automake
version to address this. This is to fix a configure error when building
with Ubuntu, where the distro version of automake is 1.11.3.

See GNU Automake 1.13 release notes:

    http://lwn.net/Articles/531373/

Issue #13.