### PR TITLE
configure: Separate paths for OpenCL headers/libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -321,21 +321,31 @@ AS_IF([test ! -d "$SKELCL_BUILD_DIR"],
 
 
 dnl ================================================================
-dnl Export OpenCL path
+dnl Export OpenCL paths
 dnl ================================================================
-AC_ARG_WITH(opencl,
-            AS_HELP_STRING([--with-opencl=DIR],
-                           [OpenCL header and library location]),
-            [opencl="$withval"],
-            [AC_MSG_WARN([using default OpenCL location.])
-             opencl="/opt/intel/opencl-sdk"])
+dnl libOpenCL.so
+AC_ARG_WITH(opencl-lib,
+            AS_HELP_STRING([--with-opencl-lib=DIR],
+                           [Location of libOpenCL.so]),
+            [opencl_lib="$withval"],
+            [AC_MSG_WARN([using default OpenCL library location.])
+             opencl_lib="/opt/intel/opencl-sdk/lib64"])
 
-CL="$opencl"
-AC_SUBST([CL],[$CL])
+OPENCL_LIB="$opencl_lib"
+AC_CHECK_FILE([$OPENCL_LIB/libOpenCL.so],[],[AC_MSG_ERROR([OpenCL library not found!])])
+AC_SUBST([OPENCL_LIB],[$OPENCL_LIB])
 
-dnl Check for OpenCL header and shared object.
-AC_CHECK_FILE([$CL/include/CL/cl.h],[],[AC_MSG_ERROR([OpenCL headers not found!])])
-AC_CHECK_FILE([$CL/lib64/libOpenCL.so],[],[AC_MSG_ERROR([OpenCL library not found!])])
+dnl OpenCL headers
+AC_ARG_WITH(opencl-headers,
+            AS_HELP_STRING([--with-opencl-headers=DIR],
+                           [Location of OpenCL include files.]),
+            [opencl_headers="$withval"],
+            [AC_MSG_WARN([using default OpenCL header location.])
+opencl_headers="/opt/intel/opencl-sdk/include"])
+
+OPENCL_HEADERS="$opencl_headers"
+AC_CHECK_FILE([$OPENCL_HEADERS/CL/cl.h],[],[AC_MSG_ERROR([OpenCL headers not found!])])
+AC_SUBST([OPENCL_HEADERS],[$OPENCL_HEADERS])
 
 
 dnl ================================================================

--- a/exercises/opencl/Makefile.am
+++ b/exercises/opencl/Makefile.am
@@ -5,12 +5,9 @@ include $(top_srcdir)/Makefile.common
 # Build targets and configuration.
 ###############################################################################
 
-CL_INCLUDE = $(CL)/include
-CL_LIB = $(CL)/lib64
-
 # Local compiler and linker flags.
-AM_CXXFLAGS = -isystem $(CL_INCLUDE)
-AM_LDFLAGS  = -L$(CL_LIB) -lOpenCL
+AM_CXXFLAGS = -isystem $(OPENCL_HEADERS)
+AM_LDFLAGS  = -L$(OPENCL_LIB) -lOpenCL
 
 #------------------------------------------------------------------------
 # Build targets.


### PR DESCRIPTION
This adds separate --with-opencl-lib and --with-opencl-headers arguments
to configure, since the OpenCL libs and header files may not share the
same prefix on some distributions.

Issue #15.