### PR TITLE
configure: Check for, and export, etags package

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -181,7 +181,7 @@ all-local: $(Plists) $(Cpplints)
 # from the built-in the rule. We then hook in our custom build logic
 # after this, generating additional source listings and performing
 # static analysis and linting.
-%.o: %.cc etags
+%.o: %.cc $(TagsFiles)
 	$(AM_V_CXX)$(CXXCOMPILE) -emit-llvm -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c $< -o $*$(BitCodeExtension)
 	$(AM_V_at)$(am__mv) $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Po
 if ENABLE_MEMORY_COUNTER
@@ -198,12 +198,16 @@ endif
 #------------------------------------------------------------------------
 # Generating TAGS files for C and C++ sources.
 #------------------------------------------------------------------------
-etags: TAGS
+TagsFiles =
+
+if HAVE_ETAGS
+TagsFiles += TAGS
 
 TAGS: $(CAll) $(CxxAll)
-	$(AM_V_at)etags $^
+	$(AM_V_at)$(ETAGS) $^
+endif
 
-MOSTLYCLEANFILES += TAGS
+MOSTLYCLEANFILES += $(TagsFiles)
 
 #------------------------------------------------------------------------
 # Show TODO and FIXME annotations in sources.

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,18 @@ AM_CONDITIONAL([HAVE_MPI_TOOLS],[test "x$HAVE_MPI_TOOLS" = xyes])
 
 
 dnl ================================================================
+dnl Do we have etags installed?
+dnl ================================================================
+AC_CHECK_PROG([ETAGS],[etags],[etags])
+AS_IF([test "x$ETAGS" != x],
+      [HAVE_ETAGS=yes],
+      [HAVE_ETAGS=no
+       AC_MSG_WARN([Unable to build tags files for source code.])])
+AC_SUBST([HAVE_ETAGS],[$HAVE_ETAGS])
+AM_CONDITIONAL([HAVE_ETAGS],[test "x$HAVE_ETAGS" = xyes])
+
+
+dnl ================================================================
 dnl Do we have pdflatex installed?
 dnl ================================================================
 AC_CHECK_PROG([PDFLATEX],[pdflatex],[pdflatex])


### PR DESCRIPTION
When building on a system without emacs' etags program, the following
error occurs:

    /bin/bash: etags: command not found

This patch adds a conditional check to the configure script to ensure
that etags is present, and to only build TAGS files if it is.

Issue #19.