### PR TITLE
Don't make specify a TAGS rule

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -190,7 +190,7 @@ all-local: $(Plists) $(Cpplints)
 # from the built-in the rule. We then hook in our custom build logic
 # after this, generating additional source listings and performing
 # static analysis and linting.
-%.o: %.cc $(TagsFiles)
+%.o: %.cc
 if HAVE_CLANGXX
 	$(AM_V_CXX)$(CXXCOMPILE) -emit-llvm -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c $< -o $*$(BitCodeExtension)
 	$(AM_V_at)$(am__mv) $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Po
@@ -210,20 +210,6 @@ else
 	$(AM_V_CXX)$(CXXCOMPILE) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c $< -o $*.o
 	$(AM_V_at)$(am__mv) $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Po
 endif
-
-#------------------------------------------------------------------------
-# Generating TAGS files for C and C++ sources.
-#------------------------------------------------------------------------
-TagsFiles =
-
-if HAVE_ETAGS
-TagsFiles += TAGS
-
-TAGS: $(CAll) $(CxxAll)
-	$(AM_V_at)$(ETAGS) $^
-endif
-
-MOSTLYCLEANFILES += $(TagsFiles)
 
 #------------------------------------------------------------------------
 # Show TODO and FIXME annotations in sources.


### PR DESCRIPTION
The TAGS file dependency chain meant that object files depended on TAGS
files, which weren't generated until compile time:

    source files -----------------+---> object files ---> all
             |----> tags files ---|

This meant that TAGS files caused object files to *always* need to be
built. This is obvious bull, especially since Automake already includes
an interface for TAGS files. See:

    http://www.gnu.org/software/automake/manual/html_node/Tags.html

Issue #21.